### PR TITLE
Dynamically generate space neighbour indices

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -67,7 +67,7 @@ def test_index_bins():
 
 def test_bins():
     x = jnp.array([[0.2, 0.2], [0.2, 0.7], [0.7, 0.2], [0.7, 0.7]])
-    b = utils.space.get_bins(x, 2, 0.5)
+    _, b = utils.space.get_bins(x, 2, 0.5)
 
     expected = jnp.arange(4)
 
@@ -99,8 +99,9 @@ def test_bins():
     ],
 )
 def test_topology(topology: str, expected: chex.Array):
-    x = utils.space.get_cell_neighbours(2, topology)
-
+    idxs = jnp.array([[0, 0], [0, 1], [1, 0], [1, 1]])
+    offsets = utils.space.get_neighbours_offsets(topology)
+    x = jax.vmap(lambda a: utils.space.neighbour_indices(a, offsets, 2))(idxs)
     assert jnp.array_equal(x, jnp.array(expected))
 
 


### PR DESCRIPTION
Generate neighbouring cell indexes dynamically for spatial transforms. This avoids memory issues when generating topology neighbours for large numbers of cells ahead of time