### PR TITLE
Restructure transforms

### DIFF
--- a/docs/source/examples/evo_boids.rst
+++ b/docs/source/examples/evo_boids.rst
@@ -40,6 +40,7 @@ First we import JAX, Chex, Flax, and Esquilax
 .. testsetup:: evo_boids
 
    from typing import Callable, Tuple
+   from functools import partial
 
 .. testcode:: evo_boids
 
@@ -85,10 +86,11 @@ add aggregates position and velocity data from neighbours in-range
 
 .. testcode:: evo_boids
 
-   @esquilax.transforms.spatial(
-       10,
-       (jnp.add, jnp.add, jnp.add, jnp.add),
-       (0, jnp.zeros(2), 0.0, 0.0),
+   @partial(
+       esquilax.transforms.spatial,
+       n_bins=10,
+       reduction=(jnp.add, jnp.add, jnp.add, jnp.add),
+       default=(0, jnp.zeros(2), 0.0, 0.0),
        include_self=False,
    )
    def observe(_k: chex.PRNGKey, _params: Params, _a: Boid, b: Boid):
@@ -180,8 +182,12 @@ to calculate reward contributions
 
 .. testcode:: evo_boids
 
-   @esquilax.transforms.spatial(
-       5, jnp.add, 0.0, include_self=False,
+   @partial(
+       esquilax.transforms.spatial,
+       n_bins=5,
+       reduction=jnp.add,
+       default=0.0,
+       include_self=False,
    )
    def reward(_k: chex.PRNGKey, params: Params, a: chex.Array, b: chex.Array):
        d = esquilax.utils.shortest_distance(a, b, norm=True)

--- a/docs/source/examples/hard_coded_boids.rst
+++ b/docs/source/examples/hard_coded_boids.rst
@@ -15,6 +15,7 @@ We first import JAX, `Chex <https://chex.readthedocs.io/en/latest/>`_, and Esqui
 
 .. testcode:: hard_coded_boids
 
+   from functools import partial
    import chex
    import jax
    import jax.numpy as jnp
@@ -54,10 +55,11 @@ Firstly agents observe the state of neighbours within a given range
 
 .. testcode:: hard_coded_boids
 
-   @esquilax.transforms.spatial(
-       5,
-       (jnp.add, jnp.add, jnp.add, jnp.add),
-       (0, jnp.zeros(2), jnp.zeros(2), jnp.zeros(2)),
+   @partial(
+       esquilax.transforms.spatial,
+       n_bins=5,
+       reduction=(jnp.add, jnp.add, jnp.add, jnp.add),
+       default=(0, jnp.zeros(2), jnp.zeros(2), jnp.zeros(2)),
        include_self=False,
    )
    def observe(_key: chex.PRNGKey, params: Params, a: Boid, b: Boid):

--- a/docs/source/examples/rl_boids.rst
+++ b/docs/source/examples/rl_boids.rst
@@ -14,6 +14,7 @@ example, but wrap them up in an environment class
 .. testsetup:: rl_boids
 
    from typing import Callable, Tuple, Any
+   from functools import partial
    import chex
    import evosax
    import flax
@@ -48,10 +49,11 @@ example, but wrap them up in an environment class
            x = flax.linen.tanh(x)
            return x
 
-   @esquilax.transforms.spatial(
-       10,
-       (jnp.add, jnp.add, jnp.add, jnp.add),
-       (0, jnp.zeros(2), 0.0, 0.0),
+   @partial(
+       esquilax.transforms.spatial,
+       n_bins=10,
+       reduction=(jnp.add, jnp.add, jnp.add, jnp.add),
+       default=(0, jnp.zeros(2), 0.0, 0.0),
        include_self=False,
    )
    def observe(_k: chex.PRNGKey, _params: Params, _a: Boid, b: Boid):
@@ -110,8 +112,12 @@ example, but wrap them up in an environment class
        )
        return (pos + d_pos) % 1.0
 
-   @esquilax.transforms.spatial(
-       5, jnp.add, 0.0, include_self=False,
+   @partial(
+       esquilax.transforms.spatial,
+       n_bins=5,
+       reduction=jnp.add,
+       default=0.0,
+       include_self=False,
    )
    def reward(_k: chex.PRNGKey, params: Params, a: chex.Array, b: chex.Array):
        d = esquilax.utils.shortest_distance(a, b, norm=True)

--- a/examples/boids/hard_coded.py
+++ b/examples/boids/hard_coded.py
@@ -1,3 +1,5 @@
+from functools import partial
+
 import chex
 import jax
 import jax.numpy as jnp
@@ -21,10 +23,11 @@ class Params:
     close_range: float
 
 
-@esquilax.transforms.spatial(
-    5,
-    (jnp.add, jnp.add, jnp.add, jnp.add),
-    (0, jnp.zeros(2), jnp.zeros(2), jnp.zeros(2)),
+@partial(
+    esquilax.transforms.spatial,
+    n_bins=5,
+    reduction=(jnp.add, jnp.add, jnp.add, jnp.add),
+    default=(0, jnp.zeros(2), jnp.zeros(2), jnp.zeros(2)),
     include_self=False,
 )
 def observe(_key: chex.PRNGKey, params: Params, a: Boids, b: Boids):

--- a/examples/boids/updates.py
+++ b/examples/boids/updates.py
@@ -1,3 +1,4 @@
+from functools import partial
 from typing import Tuple
 
 import chex
@@ -25,10 +26,11 @@ class Params:
     collision_penalty: float = 0.1
 
 
-@esquilax.transforms.spatial(
-    10,
-    (jnp.add, jnp.add, jnp.add, jnp.add),
-    (0, jnp.zeros(2), 0.0, 0.0),
+@partial(
+    esquilax.transforms.spatial,
+    n_bins=10,
+    reduction=(jnp.add, jnp.add, jnp.add, jnp.add),
+    default=(0, jnp.zeros(2), 0.0, 0.0),
     include_self=False,
 )
 def observe(_k: chex.PRNGKey, _params: Params, a: Boid, b: Boid):
@@ -87,10 +89,11 @@ def move(_key: chex.PRNGKey, _params: Params, x):
     return (pos + d_pos) % 1.0
 
 
-@esquilax.transforms.spatial(
-    5,
-    jnp.add,
-    0.0,
+@partial(
+    esquilax.transforms.spatial,
+    n_bins=5,
+    reduction=jnp.add,
+    default=0.0,
     include_self=False,
 )
 def rewards(_k: chex.PRNGKey, params: Params, a: chex.Array, b: chex.Array):

--- a/examples/opinion_dynamics.py
+++ b/examples/opinion_dynamics.py
@@ -1,3 +1,5 @@
+from functools import partial
+
 import chex
 import jax
 import jax.numpy as jnp
@@ -18,7 +20,9 @@ class SimState:
     weights: chex.Array
 
 
-@esquilax.transforms.graph_reduce((jnp.add, jnp.add), (0, 0.0))
+@partial(
+    esquilax.transforms.graph_reduce, reduction=(jnp.add, jnp.add), default=(0, 0.0)
+)
 def collect_opinions(_, params: Params, my_opinion, your_opinion, weight):
     d = jnp.abs(my_opinion - your_opinion)
     w = params.strength * weight

--- a/src/esquilax/transforms/_map.py
+++ b/src/esquilax/transforms/_map.py
@@ -31,24 +31,23 @@ def amap(f: typing.Callable) -> typing.Callable:
 
     .. testcode:: amap
 
-       @esquilax.transforms.amap
        def foo(k, p, x):
            return p + x
 
        k = jax.random.PRNGKey(101)
        a = jax.numpy.arange(5)
 
-       foo(k, 2, a)
+       esquilax.transforms.amap(foo)(k, 2, a)
        # [2, 3, 4, 5, 6]
 
     .. doctest:: amap
        :hide:
 
-       >>> foo(k, 2, a).tolist()
+       >>> esquilax.transforms.amap(foo)(k, 2, a).tolist()
        [2, 3, 4, 5, 6]
 
-    Arguments can also be PyTrees, and parameters
-    ``None`` if unused
+    It can also be used as a decortor. Arguments can
+    also be PyTrees, and parameters ``None`` if unused
 
     .. testcode:: amap
 

--- a/tests/test_transforms/test_graph_reduce.py
+++ b/tests/test_transforms/test_graph_reduce.py
@@ -10,11 +10,12 @@ def test_graph_reduce_array():
     key = jax.random.PRNGKey(101)
     edges = jnp.array([[0, 0, 1], [1, 2, 0]])
 
-    @transforms.graph_reduce(jnp.add, 0)
     def foo(_, p, x, y, z):
         return p + x + y + z
 
-    results = foo(key, 2, jnp.arange(3), jnp.arange(3), jnp.arange(3), edge_idxs=edges)
+    results = transforms.graph_reduce(foo, reduction=jnp.add, default=0)(
+        key, 2, jnp.arange(3), jnp.arange(3), jnp.arange(3), edge_idxs=edges
+    )
     expected = jnp.array([8, 5, 0])
 
     assert jnp.array_equal(results, expected)
@@ -24,11 +25,12 @@ def test_graph_reduce_array_no_starts():
     key = jax.random.PRNGKey(101)
     edges = jnp.array([[0, 0, 1], [1, 2, 0]])
 
-    @transforms.graph_reduce(jnp.add, 0, n=3)
     def foo(_, p, x, y, z):
         return p + y + z
 
-    results = foo(key, 2, None, jnp.arange(3), jnp.arange(3), edge_idxs=edges)
+    results = transforms.graph_reduce(foo, reduction=jnp.add, default=0, n=3)(
+        key, 2, None, jnp.arange(3), jnp.arange(3), edge_idxs=edges
+    )
     expected = jnp.array([8, 4, 0])
 
     assert jnp.array_equal(results, expected)
@@ -38,11 +40,12 @@ def test_graph_reduce_tuple():
     key = jax.random.PRNGKey(101)
     edges = jnp.array([[0, 0, 1], [1, 2, 0]])
 
-    @transforms.graph_reduce((jnp.add, jnp.add), (0, 0))
     def foo(_, p, x, y, z):
         return tree_util.tree_map(lambda a, b, c: p + a + b + c, x, y, z)
 
-    results = foo(
+    results = transforms.graph_reduce(
+        foo, reduction=(jnp.add, jnp.add), default=(0, 0)
+    )(
         key,
         2,
         (jnp.arange(3), jnp.arange(3)),
@@ -59,14 +62,13 @@ def test_graph_reduce_w_static():
     key = jax.random.PRNGKey(101)
     edges = jnp.array([[0, 0, 1], [1, 2, 0]])
 
-    @transforms.graph_reduce(jnp.add, 0)
     def foo(_, p, x, y, z, *, func):
         return func(p, x, y, z)
 
     def bar(a, b, c, d):
         return a + b + c + d
 
-    results = foo(
+    results = transforms.graph_reduce(foo, reduction=jnp.add, default=0)(
         key, 2, jnp.arange(3), jnp.arange(3), jnp.arange(3), func=bar, edge_idxs=edges
     )
     expected = jnp.array([8, 5, 0])

--- a/tests/test_transforms/test_heighest_weight.py
+++ b/tests/test_transforms/test_heighest_weight.py
@@ -11,11 +11,12 @@ def test_highest_weight_edge():
     weights = jnp.array([0.1, 0.4, 0.3, 0.1])
     x = jnp.arange(4)
 
-    @esquilax.transforms.highest_weight(-1)
     def foo(_k, _p, _a, b, e):
         return b + e
 
-    result = foo(key, None, x, x, x, edge_idxs=edges, weights=weights)
+    result = esquilax.transforms.highest_weight(foo, default=-1)(
+        key, None, x, x, x, edge_idxs=edges, weights=weights
+    )
 
     assert jnp.array_equal(result, jnp.array([4, -1, 2, -1]))
 
@@ -27,11 +28,12 @@ def test_highest_weight_edge_no_start():
     weights = jnp.array([0.1, 0.4, 0.3, 0.1])
     x = jnp.arange(4)
 
-    @esquilax.transforms.highest_weight(-1, n=4)
     def foo(_k, _p, _a, b, _e):
         return b
 
-    result = foo(key, None, None, x, None, edge_idxs=edges, weights=weights)
+    result = esquilax.transforms.highest_weight(foo, default=-1, n=4)(
+        key, None, None, x, None, edge_idxs=edges, weights=weights
+    )
 
     assert jnp.array_equal(result, jnp.array([3, -1, 0, -1]))
 
@@ -43,13 +45,14 @@ def test_highest_weight_edge_w_static():
     weights = jnp.array([0.1, 0.4, 0.3, 0.1])
     x = jnp.arange(4)
 
-    @esquilax.transforms.highest_weight(-1, n=4)
     def foo(_k, _p, _a, b, _e, *, f):
         return f(b)
 
     def bar(a):
         return 2 * a
 
-    result = foo(key, None, None, x, None, f=bar, edge_idxs=edges, weights=weights)
+    result = esquilax.transforms.highest_weight(foo, default=-1, n=4)(
+        key, None, None, x, None, f=bar, edge_idxs=edges, weights=weights
+    )
 
     assert jnp.array_equal(result, jnp.array([6, -1, 0, -1]))

--- a/tests/test_transforms/test_random_edge.py
+++ b/tests/test_transforms/test_random_edge.py
@@ -38,11 +38,12 @@ def test_graph_random_neighbour(args, expected, default):
     key = jax.random.PRNGKey(101)
     edges = jnp.array([[0, 0, 1], [1, 1, 2]])
 
-    @transforms.random_edge(default)
     def foo(_, p, x, y, z):
         return jax.tree_util.tree_map(lambda a, b, c: p + a + b + c, x, y, z)
 
-    results = foo(key, 2, *args, edge_idxs=edges)
+    results = transforms.random_edge(foo, default=default)(
+        key, 2, *args, edge_idxs=edges
+    )
 
     chex.assert_trees_all_equal(expected, results)
 
@@ -54,13 +55,14 @@ def test_graph_random_neighbour_w_static():
     args = jnp.arange(3), jnp.arange(3), jnp.ones((3,))
     expected = jnp.array([4, 6, -1])
 
-    @transforms.random_edge(-1.0)
     def foo(_, p, x, y, z, *, func):
         return func(p, x, y, z)
 
     def bar(a, b, c, d):
         return a + b + c + d
 
-    results = foo(key, 2, *args, func=bar, edge_idxs=edges)
+    results = transforms.random_edge(foo, default=-1.0)(
+        key, 2, *args, func=bar, edge_idxs=edges
+    )
 
     assert jnp.array_equal(results, expected)

--- a/tests/test_transforms/test_space.py
+++ b/tests/test_transforms/test_space.py
@@ -26,14 +26,25 @@ def test_spatial_interaction(
     k = jax.random.PRNGKey(101)
     x = jnp.array([[0.1, 0.1], [0.7, 0.1], [0.1, 0.7], [0.75, 0.2], [0.75, 0.75]])
 
-    @transforms.spatial(
-        2, jnp.add, 0, include_self=include_self, topology=topology, i_range=i_range
-    )
     def foo(_, params, a, b):
         return params + a + b
 
     vals = jnp.arange(5)
-    results = foo(k, 2, vals, vals, pos=x)
+    results = transforms.spatial(
+        foo,
+        n_bins=2,
+        reduction=jnp.add,
+        default=0,
+        include_self=include_self,
+        topology=topology,
+        i_range=i_range,
+    )(
+        k,
+        2,
+        vals,
+        vals,
+        pos=x,
+    )
 
     assert jnp.array_equal(
         results,
@@ -54,20 +65,26 @@ def test_spatial_w_array(expected, include_self, topology):
     k = jax.random.PRNGKey(101)
     x = jnp.array([[0.1, 0.1], [0.7, 0.1], [0.75, 0.2]])
 
-    @transforms.spatial(
-        2,
-        jnp.add,
-        jnp.zeros(2),
-        include_self=include_self,
-        topology=topology,
-        i_range=1.0,
-    )
     def foo(_, params, a, b):
         return params + a + b
 
     agents = jnp.column_stack([jnp.arange(3), jnp.arange(3) + 1])
 
-    results = foo(k, jnp.ones(2), agents, agents, pos=x)
+    results = transforms.spatial(
+        foo,
+        n_bins=2,
+        reduction=jnp.add,
+        default=jnp.zeros(2),
+        include_self=include_self,
+        topology=topology,
+        i_range=1.0,
+    )(
+        k,
+        jnp.ones(2),
+        agents,
+        agents,
+        pos=x,
+    )
 
     assert jnp.array_equal(results, jnp.array(expected))
 
@@ -85,20 +102,26 @@ def test_spatial_w_dict(expected, include_self, topology):
     k = jax.random.PRNGKey(101)
     x = jnp.array([[0.1, 0.1], [0.7, 0.1], [0.75, 0.2]])
 
-    @transforms.spatial(
-        2,
-        {"a": jnp.add, "b": jnp.add},
-        {"a": 0, "b": 0},
-        include_self=include_self,
-        topology=topology,
-        i_range=1.0,
-    )
     def foo(_, params, a, b):
         return {"a": params + a["a"] + b["a"], "b": params + a["b"] + b["b"]}
 
     agents = {"a": jnp.arange(3), "b": jnp.arange(3) + 1}
 
-    results = foo(k, 2, agents, agents, pos=x)
+    results = transforms.spatial(
+        foo,
+        n_bins=2,
+        reduction={"a": jnp.add, "b": jnp.add},
+        default={"a": 0, "b": 0},
+        include_self=include_self,
+        topology=topology,
+        i_range=1.0,
+    )(
+        k,
+        2,
+        agents,
+        agents,
+        pos=x,
+    )
 
     expected = {"a": jnp.array(expected["a"]), "b": expected["b"]}
 
@@ -119,20 +142,20 @@ def test_spatial_w_tuple(expected, include_self, topology):
     k = jax.random.PRNGKey(101)
     x = jnp.array([[0.1, 0.1], [0.7, 0.1], [0.75, 0.2]])
 
-    @transforms.spatial(
-        2,
-        (jnp.add, jnp.add),
-        (0, 0),
-        include_self=include_self,
-        topology=topology,
-        i_range=1.0,
-    )
     def foo(_, params, a, b):
         return params + a[0] + b[0], params + a[1] + b[1]
 
     agents = (jnp.arange(3), jnp.arange(3) + 1)
 
-    results = foo(k, 2, agents, agents, pos=x)
+    results = transforms.spatial(
+        foo,
+        n_bins=2,
+        reduction=(jnp.add, jnp.add),
+        default=(0, 0),
+        include_self=include_self,
+        topology=topology,
+        i_range=1.0,
+    )(k, 2, agents, agents, pos=x)
 
     expected = (jnp.array(expected[0]), jnp.array(expected[1]))
 
@@ -146,9 +169,6 @@ def test_spatial_interaction_w_static():
 
     expected = [48, 46, 72, 62, 72]
 
-    @transforms.spatial(
-        2, jnp.add, 0, include_self=False, topology="moore", i_range=10.0
-    )
     def foo(_, params, a, b, *, func):
         return func(params, a, b)
 
@@ -156,7 +176,15 @@ def test_spatial_interaction_w_static():
         return a + b + c
 
     vals = jnp.arange(5)
-    results = foo(k, 2, vals, vals, func=bar, pos=x)
+    results = transforms.spatial(
+        foo,
+        n_bins=2,
+        reduction=jnp.add,
+        default=0,
+        include_self=False,
+        topology="moore",
+        i_range=10.0,
+    )(k, 2, vals, vals, func=bar, pos=x)
 
     assert jnp.array_equal(
         results,
@@ -168,16 +196,21 @@ def test_spatial_mixed_data():
     k = jax.random.PRNGKey(101)
     x = jnp.array([[0.1, 0.1], [0.1, 0.7]])
 
-    @transforms.spatial(
-        2, jnp.add, 0, include_self=False, topology="von-neumann", i_range=10.0
-    )
     def foo(_, params, a, b):
         return params + a + b
 
     vals_a = jnp.arange(1, 3)
     vals_b = jnp.arange(6, 8)
 
-    results = foo(k, 2, vals_a, vals_b, pos=x)
+    results = transforms.spatial(
+        foo,
+        n_bins=2,
+        reduction=jnp.add,
+        default=0,
+        include_self=False,
+        topology="von-neumann",
+        i_range=10.0,
+    )(k, 2, vals_a, vals_b, pos=x)
 
     expected = [20, 20]
 
@@ -191,15 +224,20 @@ def test_spatial_w_none():
     k = jax.random.PRNGKey(101)
     x = jnp.array([[0.1, 0.1], [0.1, 0.7]])
 
-    @transforms.spatial(
-        2, jnp.add, 0, include_self=False, topology="von-neumann", i_range=10.0
-    )
     def foo(_, params, _a, b):
         return params + b
 
     vals_b = jnp.arange(1, 3)
 
-    results = foo(k, 2, None, vals_b, pos=x)
+    results = transforms.spatial(
+        foo,
+        n_bins=2,
+        reduction=jnp.add,
+        default=0,
+        include_self=False,
+        topology="von-neumann",
+        i_range=10.0,
+    )(k, 2, None, vals_b, pos=x)
 
     expected = [8, 6]
 
@@ -208,15 +246,20 @@ def test_spatial_w_none():
         jnp.array(expected),
     )
 
-    @transforms.spatial(
-        2, jnp.add, 0, include_self=False, topology="von-neumann", i_range=10.0
-    )
     def bar(_, params, a, _b):
         return params + a
 
     vals_a = jnp.arange(1, 3)
 
-    results = bar(k, 2, vals_a, None, pos=x)
+    results = transforms.spatial(
+        bar,
+        n_bins=2,
+        reduction=jnp.add,
+        default=0,
+        include_self=False,
+        topology="von-neumann",
+        i_range=10.0,
+    )(k, 2, vals_a, None, pos=x)
 
     expected = [6, 8]
 
@@ -247,16 +290,21 @@ def test_mixed_type_spatial_interaction(
     xa = jnp.array([[0.1, 0.1], [0.1, 0.7], [0.75, 0.2]])
     xb = jnp.array([[0.7, 0.1], [0.75, 0.75]])
 
-    @transforms.spatial(
-        2, jnp.add, 0, include_self=include_self, topology=topology, i_range=i_range
-    )
     def foo(_, params, a, b):
         return params + a + b
 
     vals_a = jnp.arange(3)
     vals_b = jnp.arange(1, 3)
 
-    results = foo(k, 2, vals_a, vals_b, pos=xa, pos_b=xb)
+    results = transforms.spatial(
+        foo,
+        n_bins=2,
+        reduction=jnp.add,
+        default=0,
+        include_self=include_self,
+        topology=topology,
+        i_range=i_range,
+    )(k, 2, vals_a, vals_b, pos=xa, pos_b=xb)
 
     assert jnp.array_equal(
         results,
@@ -277,12 +325,13 @@ def test_nearest_neighbour(expected: chex.Array, topology: str, i_range: float):
     k = jax.random.PRNGKey(101)
     x = jnp.array([[0.1, 0.1], [0.1, 0.2], [0.1, 0.6]])
 
-    @transforms.nearest_neighbour(2, -1, topology=topology, i_range=i_range)
     def foo(_, params, a, b):
         return params + a + b
 
     vals = jnp.arange(3)
-    results = foo(k, 2, vals, vals, pos=x)
+    results = transforms.nearest_neighbour(
+        foo, n_bins=2, default=-1, topology=topology, i_range=i_range
+    )(k, 2, vals, vals, pos=x)
 
     assert jnp.array_equal(
         results,
@@ -307,15 +356,20 @@ def test_space_fuzzy_same_type(n_agents: int, i_range: float):
     k = jax.random.PRNGKey(101)
     x = jax.random.uniform(k, (n_agents, 2))
 
-    @transforms.spatial(
-        10, jnp.add, 0, include_self=True, topology="moore", i_range=i_range
-    )
     def foo(_k, _p, a, b):
         return a - b
 
     vals_a = jnp.arange(1, n_agents + 1)
     vals_b = jnp.arange(2, n_agents + 2)
-    results = foo(k, None, vals_a, vals_b, pos=x)
+    results = transforms.spatial(
+        foo,
+        n_bins=10,
+        reduction=jnp.add,
+        default=0,
+        include_self=True,
+        topology="moore",
+        i_range=i_range,
+    )(k, None, vals_a, vals_b, pos=x)
 
     d = jax.vmap(
         lambda a: jax.vmap(lambda b: esquilax.utils.shortest_distance(a, b, norm=True))(
@@ -353,13 +407,14 @@ def test_space_fuzzy_diff_types(n_agents: int, i_range: float):
     xa = jax.random.uniform(ka, (n_agents_a, 2))
     xb = jax.random.uniform(kb, (n_agents_b, 2))
 
-    @transforms.spatial(10, jnp.add, 0, topology="moore", i_range=i_range)
     def foo(_k, _p, a, b):
         return a - b
 
     vals_a = jnp.arange(1, n_agents_a + 1)
     vals_b = jnp.arange(2, n_agents_b + 2)
-    results = foo(k, None, vals_a, vals_b, pos=xa, pos_b=xb)
+    results = transforms.spatial(
+        foo, n_bins=10, reduction=jnp.add, default=0, topology="moore", i_range=i_range
+    )(k, None, vals_a, vals_b, pos=xa, pos_b=xb)
 
     d = jax.vmap(
         lambda a: jax.vmap(lambda b: esquilax.utils.shortest_distance(a, b, norm=True))(


### PR DESCRIPTION
Flatten transform decorators, removing the nesting required for decorators with argument. Instead they can now be used inline, i.e.

```python
result = transform([init-args...])([transform-args])
```

or as decorator using partial

```python
@partial(transform, [init-args...])
def foo(...):
    ...

result = foo([transform-args])
```