### PR TITLE
Optional random key

### DIFF
--- a/docs/source/examples/hard_coded_boids.rst
+++ b/docs/source/examples/hard_coded_boids.rst
@@ -62,7 +62,7 @@ Firstly agents observe the state of neighbours within a given range
        default=(0, jnp.zeros(2), jnp.zeros(2), jnp.zeros(2)),
        include_self=False,
    )
-   def observe(_key: chex.PRNGKey, params: Params, a: Boid, b: Boid):
+   def observe(params: Params, a: Boid, b: Boid):
        v = esquilax.utils.shortest_vector(b.pos, a.pos)
        d = jnp.sum(v**2)
 
@@ -96,7 +96,7 @@ The next transformation combines the observations into a steering vector
 .. testcode:: hard_coded_boids
 
    @esquilax.transforms.amap
-   def steering(_key: chex.PRNGKey, params: Params, observations):
+   def steering(params: Params, observations):
        x, v, n_nb, x_nb, v_nb, v_cl = observations
 
        def steer():
@@ -122,7 +122,7 @@ position
 .. testcode:: hard_coded_boids
 
    @esquilax.transforms.amap
-   def limit_speed(_key: chex.PRNGKey, params: Params, v: chex.Array):
+   def limit_speed(params: Params, v: chex.Array):
        s = jnp.sqrt(jnp.sum(v * v))
 
        v = jax.lax.cond(
@@ -143,7 +143,7 @@ position
 
 
    @esquilax.transforms.amap
-   def move(_key: chex.PRNGKey, _params: Params, x):
+   def move(_params: Params, x):
        pos, vel = x
        return (pos + vel) % 1.0
 
@@ -169,16 +169,15 @@ For the boids model this looks like:
 
 .. testcode:: hard_coded_boids
 
-   def step(_i, k, params: Params, boids: Boid):
-       n_nb, x_nb, v_nb, v_cl = observe(k, params, boids, boids, pos=boids.pos)
+   def step(_i, _k, params: Params, boids: Boid):
+       n_nb, x_nb, v_nb, v_cl = observe(params, boids, boids, pos=boids.pos)
 
        vel = steering(
-           k,
            params,
            (boids.pos, boids.vel, n_nb, x_nb, v_nb, v_cl)
        )
-       vel = limit_speed(k, params, vel)
-       pos = move(k, params, (boids.pos, vel))
+       vel = limit_speed(params, vel)
+       pos = move(params, (boids.pos, vel))
 
        return Boid(pos=pos, vel=vel), pos
 

--- a/examples/boids/evolutionary.py
+++ b/examples/boids/evolutionary.py
@@ -52,12 +52,12 @@ class BoidEnv(esquilax.Sim[updates.Params, updates.Boid]):
         agent_params,
     ):
         n_nb, x_nb, s_nb, h_nb = updates.observe(k, params, boids, boids, pos=boids.pos)
-        obs = updates.flatten_observations(k, params, (boids, n_nb, x_nb, s_nb, h_nb))
+        obs = updates.flatten_observations(params, (boids, n_nb, x_nb, s_nb, h_nb))
         actions = esquilax.ml.get_actions(
             self.apply_fun, self.shared_policy, agent_params, obs
         )
-        headings, speeds = updates.update_velocity(k, params, (actions, boids))
-        pos = updates.move(k, params, (boids.pos, headings, speeds))
+        headings, speeds = updates.update_velocity(params, (actions, boids))
+        pos = updates.move(params, (boids.pos, headings, speeds))
         rewards = updates.rewards(k, params, pos, pos, pos=pos)
         boids = updates.Boid(pos=pos, heading=headings, speed=speeds)
 

--- a/examples/boids/evolutionary.py
+++ b/examples/boids/evolutionary.py
@@ -45,20 +45,20 @@ class BoidEnv(esquilax.Sim[updates.Params, updates.Boid]):
     def step(
         self,
         _i: int,
-        k: chex.PRNGKey,
+        _k: chex.PRNGKey,
         params: updates.Params,
         boids: updates.Boid,
         *,
         agent_params,
     ):
-        n_nb, x_nb, s_nb, h_nb = updates.observe(k, params, boids, boids, pos=boids.pos)
+        n_nb, x_nb, s_nb, h_nb = updates.observe(params, boids, boids, pos=boids.pos)
         obs = updates.flatten_observations(params, (boids, n_nb, x_nb, s_nb, h_nb))
         actions = esquilax.ml.get_actions(
             self.apply_fun, self.shared_policy, agent_params, obs
         )
         headings, speeds = updates.update_velocity(params, (actions, boids))
         pos = updates.move(params, (boids.pos, headings, speeds))
-        rewards = updates.rewards(k, params, pos, pos, pos=pos)
+        rewards = updates.rewards(params, pos, pos, pos=pos)
         boids = updates.Boid(pos=pos, heading=headings, speed=speeds)
 
         return boids, esquilax.ml.evo.TrainingData(

--- a/examples/boids/hard_coded.py
+++ b/examples/boids/hard_coded.py
@@ -30,7 +30,7 @@ class Params:
     default=(0, jnp.zeros(2), jnp.zeros(2), jnp.zeros(2)),
     include_self=False,
 )
-def observe(_key: chex.PRNGKey, params: Params, a: Boids, b: Boids):
+def observe(params: Params, a: Boids, b: Boids):
     """Aggregate the position and velocities of neighbouring agents"""
     v = esquilax.utils.shortest_vector(b.pos, a.pos)
     d = jnp.sum(v**2)
@@ -94,11 +94,11 @@ def move(_params: Params, x):
     return (pos + vel) % 1.0
 
 
-def step(_i: int, k: chex.PRNGKey, params: Params, boids: Boids):
+def step(_i: int, _k: chex.PRNGKey, params: Params, boids: Boids):
     """
     Simulation step and aggregate agent positions
     """
-    n_nb, x_nb, v_nb, v_cl = observe(k, params, boids, boids, pos=boids.pos)
+    n_nb, x_nb, v_nb, v_cl = observe(params, boids, boids, pos=boids.pos)
 
     vel = steering(params, (boids.pos, boids.vel, n_nb, x_nb, v_nb, v_cl))
     vel = limit_speed(params, vel)

--- a/examples/boids/hard_coded.py
+++ b/examples/boids/hard_coded.py
@@ -45,7 +45,7 @@ def observe(_key: chex.PRNGKey, params: Params, a: Boids, b: Boids):
 
 
 @esquilax.transforms.amap
-def steering(_key: chex.PRNGKey, params: Params, observations):
+def steering(params: Params, observations):
     """
     Calculate new agent velocities from local flock observations
     """
@@ -65,7 +65,7 @@ def steering(_key: chex.PRNGKey, params: Params, observations):
 
 
 @esquilax.transforms.amap
-def limit_speed(_key: chex.PRNGKey, params: Params, v: chex.Array):
+def limit_speed(params: Params, v: chex.Array):
     """
     Limit the upper-lower speed of agents
     """
@@ -86,7 +86,7 @@ def limit_speed(_key: chex.PRNGKey, params: Params, v: chex.Array):
 
 
 @esquilax.transforms.amap
-def move(_key: chex.PRNGKey, _params: Params, x):
+def move(_params: Params, x):
     """
     Update agent positions
     """
@@ -100,9 +100,9 @@ def step(_i: int, k: chex.PRNGKey, params: Params, boids: Boids):
     """
     n_nb, x_nb, v_nb, v_cl = observe(k, params, boids, boids, pos=boids.pos)
 
-    vel = steering(k, params, (boids.pos, boids.vel, n_nb, x_nb, v_nb, v_cl))
-    vel = limit_speed(k, params, vel)
-    pos = move(k, params, (boids.pos, vel))
+    vel = steering(params, (boids.pos, boids.vel, n_nb, x_nb, v_nb, v_cl))
+    vel = limit_speed(params, vel)
+    pos = move(params, (boids.pos, vel))
 
     return Boids(pos=pos, vel=vel), pos
 

--- a/examples/boids/rl.py
+++ b/examples/boids/rl.py
@@ -65,8 +65,8 @@ class BoidEnv(ml.rl.Environment[updates.Params, updates.Boid]):
         """
         Update the state of the environment
         """
-        headings, speeds = updates.update_velocity(key, params, (actions, state))
-        pos = updates.move(key, params, (state.pos, headings, speeds))
+        headings, speeds = updates.update_velocity(params, (actions, state))
+        pos = updates.move(params, (state.pos, headings, speeds))
         rewards = updates.rewards(key, params, pos, pos, pos=pos)
         boids = updates.Boid(pos=pos, heading=headings, speed=speeds)
         obs = self.get_obs(key, params, boids)
@@ -84,7 +84,7 @@ class BoidEnv(ml.rl.Environment[updates.Params, updates.Boid]):
         n_nb, x_nb, s_nb, h_nb = updates.observe(
             key, params, state, state, pos=state.pos
         )
-        obs = updates.flatten_observations(key, params, (state, n_nb, x_nb, s_nb, h_nb))
+        obs = updates.flatten_observations(params, (state, n_nb, x_nb, s_nb, h_nb))
         return obs
 
 

--- a/examples/boids/rl.py
+++ b/examples/boids/rl.py
@@ -52,7 +52,7 @@ class BoidEnv(ml.rl.Environment[updates.Params, updates.Boid]):
                 k3, (self.n_agents,), minval=0.0, maxval=2.0 * jnp.pi
             ),
         )
-        obs = self.get_obs(key, params, boids)
+        obs = self.get_obs(params, boids)
         return obs, boids
 
     def step(
@@ -67,23 +67,20 @@ class BoidEnv(ml.rl.Environment[updates.Params, updates.Boid]):
         """
         headings, speeds = updates.update_velocity(params, (actions, state))
         pos = updates.move(params, (state.pos, headings, speeds))
-        rewards = updates.rewards(key, params, pos, pos, pos=pos)
+        rewards = updates.rewards(params, pos, pos, pos=pos)
         boids = updates.Boid(pos=pos, heading=headings, speed=speeds)
-        obs = self.get_obs(key, params, boids)
+        obs = self.get_obs(params, boids)
         return obs, state, rewards, False
 
     def get_obs(
         self,
-        key: chex.PRNGKey,
         params: updates.Params,
         state: updates.Boid,
     ) -> chex.Array:
         """
         Get an observation array from environment state
         """
-        n_nb, x_nb, s_nb, h_nb = updates.observe(
-            key, params, state, state, pos=state.pos
-        )
+        n_nb, x_nb, s_nb, h_nb = updates.observe(params, state, state, pos=state.pos)
         obs = updates.flatten_observations(params, (state, n_nb, x_nb, s_nb, h_nb))
         return obs
 

--- a/examples/boids/updates.py
+++ b/examples/boids/updates.py
@@ -33,7 +33,7 @@ class Params:
     default=(0, jnp.zeros(2), 0.0, 0.0),
     include_self=False,
 )
-def observe(_k: chex.PRNGKey, _params: Params, a: Boid, b: Boid):
+def observe(_params: Params, a: Boid, b: Boid):
     """
     Count neighbours and accumulate their relative velocities and positions
     """
@@ -104,7 +104,7 @@ def move(_params: Params, x):
     default=0.0,
     include_self=False,
 )
-def rewards(_k: chex.PRNGKey, params: Params, a: chex.Array, b: chex.Array):
+def rewards(params: Params, a: chex.Array, b: chex.Array):
     """Calculate rewards based on distance from neighbours"""
     d = esquilax.utils.shortest_distance(a, b, norm=True)
 

--- a/examples/boids/updates.py
+++ b/examples/boids/updates.py
@@ -43,7 +43,7 @@ def observe(_k: chex.PRNGKey, _params: Params, a: Boid, b: Boid):
 
 
 @esquilax.transforms.amap
-def flatten_observations(_k: chex.PRNGKey, params: Params, observations):
+def flatten_observations(params: Params, observations):
     """
     Convert aggregate neighbour observation into a flattened array
     """
@@ -71,7 +71,7 @@ def flatten_observations(_k: chex.PRNGKey, params: Params, observations):
 
 
 @esquilax.transforms.amap
-def update_velocity(_k: chex.PRNGKey, params: Params, x: Tuple[chex.Array, Boid]):
+def update_velocity(params: Params, x: Tuple[chex.Array, Boid]):
     """
     Update agent velocities from actions
     """
@@ -90,7 +90,7 @@ def update_velocity(_k: chex.PRNGKey, params: Params, x: Tuple[chex.Array, Boid]
 
 
 @esquilax.transforms.amap
-def move(_key: chex.PRNGKey, _params: Params, x):
+def move(_params: Params, x):
     """Update agent positions based on current velocity"""
     pos, heading, speed = x
     d_pos = jnp.array([speed * jnp.cos(heading), speed * jnp.sin(heading)])

--- a/examples/opinion_dynamics.py
+++ b/examples/opinion_dynamics.py
@@ -23,7 +23,7 @@ class SimState:
 @partial(
     esquilax.transforms.graph_reduce, reduction=(jnp.add, jnp.add), default=(0, 0.0)
 )
-def collect_opinions(_, params: Params, my_opinion, your_opinion, weight):
+def collect_opinions(params: Params, my_opinion, your_opinion, weight):
     """
     Observe opinion of neighbouring nodes, add contributions if difference of
     opinion is below a given threshold
@@ -43,7 +43,7 @@ def step(_, k, params: Params, state: SimState):
     Simulation step
     """
     n, new_opinions = collect_opinions(
-        k, params, state.opinions, state.opinions, state.weights, edge_idxs=state.edges
+        params, state.opinions, state.opinions, state.weights, edge_idxs=state.edges
     )
 
     new_opinions = jnp.where(n > 0, new_opinions / n, state.opinions)

--- a/src/esquilax/transforms/_graph.py
+++ b/src/esquilax/transforms/_graph.py
@@ -126,10 +126,7 @@ def edge_map(f: Callable) -> Callable:
         key: Optional[chex.PRNGKey] = None,
         **static_kwargs,
     ) -> chex.ArrayTree:
-        if has_key:
-            assert key is not None, "Expected keyword argument 'key'"
-        else:
-            assert key is None, "Received unexpected 'key' keyword argument"
+        utils.functions.check_key(has_key, key)
         chex.assert_tree_has_only_ndarrays(starts)
         chex.assert_tree_has_only_ndarrays(ends)
         chex.assert_tree_has_only_ndarrays(edge_idxs)
@@ -591,10 +588,8 @@ def highest_weight(f: Callable, *, default: Default, n: int = -1) -> Callable:
     ) -> Any:
         if starts is None:
             assert n > 0, "If starts is not provided, n should be provided"
-        if has_key:
-            assert key is not None, "Expected keyword argument 'key'"
-        else:
-            assert key is None, "Received unexpected 'key' keyword argument"
+
+        utils.functions.check_key(has_key, key)
         chex.assert_tree_has_only_ndarrays(starts)
         chex.assert_tree_has_only_ndarrays(ends)
         chex.assert_tree_has_only_ndarrays(edges)

--- a/src/esquilax/transforms/_grid.py
+++ b/src/esquilax/transforms/_grid.py
@@ -234,11 +234,7 @@ def grid(
         key: Optional[chex.PRNGKey] = None,
         **static_kwargs,
     ) -> Any:
-        if has_key:
-            assert key is not None, "Expected keyword argument 'key'"
-        else:
-            assert key is None, "Received unexpected 'key' keyword argument"
-
+        utils.functions.check_key(has_key, key)
         _check_arguments(co_ords, co_ords_b, agents_a, agents_b)
         same_types = co_ords_b is None
 
@@ -462,13 +458,8 @@ def grid_local(
         co_ords: chex.Array,
         **static_kwargs,
     ) -> chex.ArrayTree:
-        assert grids is not None
-
-        if has_key:
-            assert key is not None, "Expected keyword argument 'key'"
-        else:
-            assert key is None, "Received unexpected 'key' keyword argument"
-
+        assert grids is not None, "'grids' argument should not be None"
+        utils.functions.check_key(has_key, key)
         dims = jax.tree.flatten(grids)[0][0].shape[:2]
         chex.assert_tree_shape_prefix(grids, dims)
         dims = jnp.array(dims)

--- a/src/esquilax/transforms/_space.py
+++ b/src/esquilax/transforms/_space.py
@@ -160,12 +160,11 @@ def spatial(
 
     .. testcode:: spatial
 
-       def foo(_k, p, a, b):
+       def foo(p, a, b):
            return p + a + b
 
        x = jnp.array([[0.1, 0.1], [0.6, 0.6], [0.7, 0.7]])
        a = jnp.arange(3)
-       k = jax.random.PRNGKey(101)
 
        result = esquilax.transforms.spatial(
            foo,
@@ -174,7 +173,7 @@ def spatial(
            default=0,
            include_self=False,
        )(
-           k, 2, a, a, pos=x
+           2, a, a, pos=x
        )
        # result = [0, 5, 5]
 
@@ -202,20 +201,19 @@ def spatial(
            include_self=False,
            topology="same-cell",
        )
-       def foo(_k, p, _, b):
+       def foo(p, _, b):
            return p + b[0],  p + b[1]
 
        x = jnp.array([[0.1, 0.1], [0.6, 0.6], [0.7, 0.7]])
        a = jnp.arange(6).reshape(3, 2)
-       k = jax.random.PRNGKey(101)
 
-       foo(k, 2, None, a, pos=x)
-       # ([0, 6, 4], [0, 7, 5])
+       result = foo(2, None, a, pos=x)
+       # result = ([0, 6, 4], [0, 7, 5])
 
     .. doctest:: spatial
        :hide:
 
-       >>> foo(k, 2, None, a, pos=x)
+       >>> result
        (Array([0, 6, 4], dtype=int32), Array([0, 7, 5], dtype=int32))
 
     You can also pass different agent types (i.e. two sets
@@ -231,7 +229,7 @@ def spatial(
            default=0,
            topology="moore",
        )
-       def foo(_, params, a, b):
+       def foo(params, a, b):
            return params + a + b
 
        # A consists of 3 agents, and b 2 agents
@@ -240,14 +238,33 @@ def spatial(
        vals_a = jnp.arange(3)
        vals_b = jnp.arange(1, 3)
 
-       foo(k, 2, vals_a, vals_b, pos=xa, pos_b=xb)
-       # [22, 10, 17]
+       result = foo(2, vals_a, vals_b, pos=xa, pos_b=xb)
+       # result = [22, 10, 17]
 
     .. doctest:: spatial
        :hide:
 
-       >>> foo(k, 2, vals_a, vals_b, pos=xa, pos_b=xb)
+       >>> result
        Array([22, 10, 17], dtype=int32)
+
+    Random keys can be passed to the wrapped function
+    by including the ``key`` keyword argument
+
+    .. testcode:: spatial
+
+       def foo(_p, _a, _b, *, key):
+           return jax.random.choice(key, 100, ())
+
+       k = jax.random.PRNGKey(101)
+       result = esquilax.transforms.spatial(
+           foo,
+           i_range=0.5,
+           reduction=jnp.add,
+           default=0,
+           include_self=False,
+       )(
+           None, None, None, pos=x, key=k
+       )
 
     Parameters
     ----------
@@ -258,7 +275,6 @@ def spatial(
         .. code-block:: python
 
            def f(
-               k: chex.PRNGKey,
                params: Any,
                a: Any,
                b: Any,
@@ -269,12 +285,14 @@ def spatial(
 
         where
 
-        - ``k``: Is a JAX random key
         - ``params``: Parameters broadcast over all interactions
         - ``a``: Start agent in the interaction
         - ``b``: End agent in the interaction
         - ``**static_kwargs``: Any arguments required at compile
           time by JAX can be passed as keyword arguments.
+
+        JAX random keys can be passed to the function by including
+        the ``key`` keyword argument.
     reduction
         Binary monoidal reduction function, eg ``jax.numpy.add``.
     default
@@ -490,12 +508,11 @@ def nearest_neighbour(
 
     .. testcode:: spatial
 
-       def foo(_k, p, a, b):
+       def foo(p, a, b):
            return p + a + b
 
        x = jnp.array([[0.4, 0.4], [0.6, 0.6], [0.7, 0.7]])
        a = jnp.arange(3)
-       k = jax.random.PRNGKey(101)
 
        result = esquilax.transforms.nearest_neighbour(
            foo,
@@ -503,7 +520,7 @@ def nearest_neighbour(
            default=-1,
            topology="moore"
        )(
-           k, 2, a, a, pos=x
+           2, a, a, pos=x
        )
        # result = [3, 5, 5]
 
@@ -529,20 +546,19 @@ def nearest_neighbour(
            default=(-1, -2),
            topology="moore",
        )
-       def foo(_k, p, _, b):
+       def foo(p, _, b):
            return p + b[0],  p + b[1]
 
        x = jnp.array([[0.1, 0.1], [0.6, 0.6], [0.7, 0.7]])
        a = jnp.arange(6).reshape(3, 2)
-       k = jax.random.PRNGKey(101)
 
-       foo(k, 2, None, a, pos=x)
-       # ([-1, 6, 4], [-2, 7, 5])
+       result = foo(2, None, a, pos=x)
+       # result = ([-1, 6, 4], [-2, 7, 5])
 
     .. doctest:: spatial
        :hide:
 
-       >>> foo(k, 2, None, a, pos=x)
+       >>> result
        (Array([-1,  6,  4], dtype=int32), Array([-2,  7,  5], dtype=int32))
 
     You can also pass different agent types (i.e. two sets
@@ -557,7 +573,7 @@ def nearest_neighbour(
            default=-1,
            topology="moore",
        )
-       def foo(_, params, a, b):
+       def foo(params, a, b):
            return params + a + b
 
        # A consists of a single agents, and b 2 agents
@@ -566,14 +582,32 @@ def nearest_neighbour(
        vals_a = jnp.array([1])
        vals_b = jnp.array([2, 12])
 
-       foo(k, 2, vals_a, vals_b, pos=xa, pos_b=xb)
-       # [5]
+       result = foo(2, vals_a, vals_b, pos=xa, pos_b=xb)
+       # result = [5]
 
     .. doctest:: spatial
        :hide:
 
-       >>> foo(k, 2, vals_a, vals_b, pos=xa, pos_b=xb)
+       >>> result
        Array([5], dtype=int32)
+
+    Random keys can be passed to the wrapped function by
+    using the ``key`` keyword argument
+
+    .. testcode:: spatial
+
+       def foo(p, a, b, *, key):
+           return jax.random.choice(key, 100, ())
+
+       k = jax.random.PRNGKey(101)
+       result = esquilax.transforms.nearest_neighbour(
+           foo,
+           i_range=0.5,
+           default=-1,
+           topology="moore"
+       )(
+           None, None, None, pos=x, key=k
+       )
 
     Parameters
     ----------
@@ -584,7 +618,6 @@ def nearest_neighbour(
         .. code-block:: python
 
            def f(
-               k: chex.PRNGKey,
                params: Any,
                a: Any,
                b: Any,
@@ -601,6 +634,9 @@ def nearest_neighbour(
         - ``b``: End agent in the interaction
         - ``**static_kwargs``: Any arguments required at compile
           time by JAX can be passed as keyword arguments.
+
+        Random keys can be passed to the function by including
+        the ``key`` keyword argument.
     default
         Default value(s) returned if no-neighbours are in
         range of an agent.

--- a/src/esquilax/transforms/_space.py
+++ b/src/esquilax/transforms/_space.py
@@ -333,10 +333,7 @@ def spatial(
         **static_kwargs,
     ) -> Any:
         _check_arguments(pos, pos_b, agents_a, agents_b)
-        if has_key:
-            assert key is not None, "Expected keyword argument 'key'"
-        else:
-            assert key is None, "Received unexpected 'key' keyword argument"
+        utils.functions.check_key(has_key, key)
 
         same_types = pos_b is None
 
@@ -650,10 +647,7 @@ def nearest_neighbour(
         **static_kwargs,
     ) -> Any:
         _check_arguments(pos, pos_b, agents_a, agents_b)
-        if has_key:
-            assert key is not None, "Expected keyword argument 'key'"
-        else:
-            assert key is None, "Received unexpected 'key' keyword argument"
+        utils.functions.check_key(has_key, key)
 
         same_types = pos_b is None
 

--- a/src/esquilax/utils/functions.py
+++ b/src/esquilax/utils/functions.py
@@ -2,7 +2,7 @@
 Function and data utilities
 """
 import inspect
-from typing import Callable, List
+from typing import Callable, List, Tuple
 
 import chex
 import jax
@@ -82,3 +82,22 @@ def get_keyword_args(f: Callable) -> List[str]:
         k for k, p in sig.parameters.items() if p.kind == inspect.Parameter.KEYWORD_ONLY
     ]
     return key_word_args
+
+
+def has_key_keyword(keyword_args: List[str]) -> Tuple[bool, List[str]]:
+    """
+    Check if list of arguments contains the "key" keyword
+
+    Parameters
+    ----------
+    keyword_args
+        List of keyword arguments
+
+    Returns
+    -------
+    tuple[bool, list[str]]
+        Flag if "key" was present, and updated list of arguments
+    """
+    has_key = "key" in keyword_args
+    keys = [k for k in keyword_args if k != "key"]
+    return has_key, keys

--- a/src/esquilax/utils/functions.py
+++ b/src/esquilax/utils/functions.py
@@ -2,7 +2,7 @@
 Function and data utilities
 """
 import inspect
-from typing import Callable, List, Tuple
+from typing import Callable, List, Optional, Tuple
 
 import chex
 import jax
@@ -101,3 +101,25 @@ def has_key_keyword(keyword_args: List[str]) -> Tuple[bool, List[str]]:
     has_key = "key" in keyword_args
     keys = [k for k in keyword_args if k != "key"]
     return has_key, keys
+
+
+def check_key(has_key: bool, key: Optional[chex.PRNGKey]) -> None:
+    """
+    Assert if a key instance has/not been provided if expected
+
+    Parameters
+    ----------
+    has_key
+        Flag indicating if a wrapped function expects a JAX random key
+    key
+        Optional JAX random key that should be None if ``has_key`` is
+        ``False`` or an instance of a JAX key otherwise.
+
+    Returns
+    -------
+
+    """
+    if has_key:
+        assert key is not None, "Expected keyword argument 'key'"
+    else:
+        assert key is None, "Received unexpected 'key' keyword argument"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import jax
+import pytest
+
+
+@pytest.fixture
+def rng_key():
+    return jax.random.PRNGKey(101)

--- a/tests/test_transforms/test_edge_map.py
+++ b/tests/test_transforms/test_edge_map.py
@@ -1,6 +1,6 @@
 import chex
-import jax
 import jax.numpy as jnp
+import jax.random
 import pytest
 from jax import tree_util
 
@@ -36,57 +36,64 @@ from esquilax import transforms
     ],
 )
 def test_edge_map(args, expected):
-    key = jax.random.PRNGKey(101)
-
     edges = jnp.array([[0, 0, 1], [1, 2, 0]])
 
     @transforms.edge_map
-    def foo(_, p, x, y, z):
+    def foo(p, x, y, z):
         return tree_util.tree_map(lambda a, b, c: p + a + b + c, x, y, z)
 
-    results = foo(key, 2, *args, edge_idxs=edges)
+    results = foo(2, *args, edge_idxs=edges)
 
     chex.assert_trees_all_equal(expected, results)
 
 
 def test_edge_map_with_none():
-    key = jax.random.PRNGKey(101)
-
     edges = jnp.array([[0, 0, 1], [1, 2, 0]])
 
     @transforms.edge_map
-    def foo(_, p, x, y, _z):
+    def foo(p, x, y, _z):
         return p + x + y
 
-    results = foo(key, 2, jnp.arange(3), jnp.arange(3), None, edge_idxs=edges)
+    results = foo(2, jnp.arange(3), jnp.arange(3), None, edge_idxs=edges)
     expected = jnp.array([3, 4, 3])
 
     assert jnp.array_equal(results, expected)
 
     @transforms.edge_map
-    def bar(_, p, x, _y, z):
+    def bar(p, x, _y, z):
         return p + x + z
 
-    results = bar(key, 2, jnp.arange(3), None, jnp.arange(3), edge_idxs=edges)
+    results = bar(2, jnp.arange(3), None, jnp.arange(3), edge_idxs=edges)
     expected = jnp.array([2, 3, 5])
 
     assert jnp.array_equal(results, expected)
 
 
 def test_edge_map_with_static():
-    key = jax.random.PRNGKey(101)
-
     edges = jnp.array([[0, 0, 1], [1, 2, 0]])
 
     @transforms.edge_map
-    def foo(_, p, x, y, z, *, func):
+    def foo(p, x, y, z, *, func):
         return func(p, x, y, z)
 
     def bar(a, b, c, d):
         return a + b + c + d
 
     r = jnp.arange(3)
-    results = foo(key, 2, r, r, r, func=bar, edge_idxs=edges)
+    results = foo(2, r, r, r, func=bar, edge_idxs=edges)
     expected = jnp.array([3, 5, 5])
 
     assert jnp.array_equal(results, expected)
+
+
+def test_edge_map_with_rng(rng_key: chex.PRNGKey):
+    edges = jnp.array([[0, 0, 1], [1, 2, 0]])
+
+    @transforms.edge_map
+    def foo(_p, _x, _y, _z, *, key):
+        return jax.random.choice(key, 10_000, ())
+
+    results = foo(None, None, None, None, edge_idxs=edges, key=rng_key)
+
+    assert results.shape == (3,)
+    assert jnp.unique(results).shape == (3,)

--- a/tests/test_transforms/test_grid_local.py
+++ b/tests/test_transforms/test_grid_local.py
@@ -1,22 +1,18 @@
-import jax
+import chex
 import jax.numpy as jnp
 
 from esquilax import transforms
 
 
 def test_grid_local():
-    k = jax.random.PRNGKey(101)
-
     grid = jnp.arange(25).reshape(5, 5)
     x = jnp.array([[1, 1], [4, 4]])
     y = jnp.arange(2)
 
-    def foo(_, p, a, g):
+    def foo(p, a, g):
         return g + a + p
 
-    result = transforms.grid_local(foo, topology="von-neumann")(
-        k, 2, y, grid, co_ords=x
-    )
+    result = transforms.grid_local(foo, topology="von-neumann")(2, y, grid, co_ords=x)
 
     assert result.shape == (2, 5)
     expected = jnp.array([[8, 9, 13, 7, 3], [27, 23, 7, 26, 22]])
@@ -24,18 +20,14 @@ def test_grid_local():
 
 
 def test_grid_local_return_tuple():
-    k = jax.random.PRNGKey(101)
-
     grid = jnp.arange(25).reshape(5, 5)
     x = jnp.array([[1, 1], [4, 4]])
     y = jnp.arange(2)
 
-    def foo(_, p, a, g):
+    def foo(p, a, g):
         return p + a + g[0], p + a + g[-1]
 
-    result = transforms.grid_local(foo, topology="von-neumann")(
-        k, 2, y, grid, co_ords=x
-    )
+    result = transforms.grid_local(foo, topology="von-neumann")(2, y, grid, co_ords=x)
 
     assert isinstance(result, tuple)
     expected_0 = jnp.array([8, 27])
@@ -43,3 +35,18 @@ def test_grid_local_return_tuple():
 
     assert jnp.array_equal(result[0], expected_0)
     assert jnp.array_equal(result[1], expected_1)
+
+
+def test_grid_local_w_key(rng_key: chex.PRNGKey):
+    grid = jnp.arange(25).reshape(5, 5)
+    x = jnp.array([[1, 1], [4, 4]])
+
+    def foo(p, a, g, *, key):
+        return key
+
+    result = transforms.grid_local(foo, topology="von-neumann")(
+        None, None, grid, co_ords=x, key=rng_key
+    )
+
+    assert result.shape == (2, 2)
+    assert not jnp.array_equal(result[0], result[1])

--- a/tests/test_transforms/test_heighest_weight.py
+++ b/tests/test_transforms/test_heighest_weight.py
@@ -1,58 +1,68 @@
-import jax
+import chex
 import jax.numpy as jnp
+import jax.random
 
 import esquilax
 
 
 def test_highest_weight_edge():
-    key = jax.random.PRNGKey(101)
-
     edges = jnp.array([[0, 0, 2, 2], [2, 3, 0, 1]])
     weights = jnp.array([0.1, 0.4, 0.3, 0.1])
     x = jnp.arange(4)
 
-    def foo(_k, _p, _a, b, e):
+    def foo(_p, _a, b, e):
         return b + e
 
     result = esquilax.transforms.highest_weight(foo, default=-1)(
-        key, None, x, x, x, edge_idxs=edges, weights=weights
+        None, x, x, x, edge_idxs=edges, weights=weights
     )
 
     assert jnp.array_equal(result, jnp.array([4, -1, 2, -1]))
 
 
 def test_highest_weight_edge_no_start():
-    key = jax.random.PRNGKey(101)
-
     edges = jnp.array([[0, 0, 2, 2], [2, 3, 0, 1]])
     weights = jnp.array([0.1, 0.4, 0.3, 0.1])
     x = jnp.arange(4)
 
-    def foo(_k, _p, _a, b, _e):
+    def foo(_p, _a, b, _e):
         return b
 
     result = esquilax.transforms.highest_weight(foo, default=-1, n=4)(
-        key, None, None, x, None, edge_idxs=edges, weights=weights
+        None, None, x, None, edge_idxs=edges, weights=weights
     )
 
     assert jnp.array_equal(result, jnp.array([3, -1, 0, -1]))
 
 
 def test_highest_weight_edge_w_static():
-    key = jax.random.PRNGKey(101)
-
     edges = jnp.array([[0, 0, 2, 2], [2, 3, 0, 1]])
     weights = jnp.array([0.1, 0.4, 0.3, 0.1])
     x = jnp.arange(4)
 
-    def foo(_k, _p, _a, b, _e, *, f):
+    def foo(_p, _a, b, _e, *, f):
         return f(b)
 
     def bar(a):
         return 2 * a
 
     result = esquilax.transforms.highest_weight(foo, default=-1, n=4)(
-        key, None, None, x, None, f=bar, edge_idxs=edges, weights=weights
+        None, None, x, None, f=bar, edge_idxs=edges, weights=weights
     )
 
     assert jnp.array_equal(result, jnp.array([6, -1, 0, -1]))
+
+
+def test_highest_weight_edge_w_rng(rng_key: chex.PRNGKey):
+    edges = jnp.array([[0, 0, 2], [2, 0, 1]])
+    weights = jnp.array([0.1, 0.3, 0.1])
+
+    def foo(_p, _a, _b, _e, *, key):
+        return jax.random.choice(key, 10_000, ())
+
+    result = esquilax.transforms.highest_weight(foo, default=-1, n=3)(
+        None, None, None, None, edge_idxs=edges, weights=weights, key=rng_key
+    )
+
+    assert result.shape == (3,)
+    assert jnp.unique(result).shape == (3,)

--- a/tests/test_transforms/test_nearest_neighbour.py
+++ b/tests/test_transforms/test_nearest_neighbour.py
@@ -1,0 +1,76 @@
+from typing import List, Tuple, Union
+
+import chex
+import jax.numpy as jnp
+import jax.random
+import pytest
+
+from esquilax import transforms
+
+
+@pytest.mark.parametrize(
+    "expected, topology, i_range",
+    [
+        ([3, 3, -1], "same-cell", 10.0),
+        ([3, 3, 5], "von-neumann", 10.0),
+        ([3, 3, 5], "moore", 10.0),
+        ([-1, -1, -1], "moore", 0.00001),
+    ],
+)
+def test_nearest_neighbour(expected: chex.Array, topology: str, i_range: float):
+    x = jnp.array([[0.1, 0.1], [0.1, 0.2], [0.1, 0.6]])
+
+    def foo(params, a, b):
+        return params + a + b
+
+    vals = jnp.arange(3)
+    results = transforms.nearest_neighbour(
+        foo, n_bins=2, default=-1, topology=topology, i_range=i_range
+    )(2, vals, vals, pos=x)
+
+    assert jnp.array_equal(
+        results,
+        jnp.array(expected),
+    )
+
+
+@pytest.mark.parametrize(
+    "x, i_range, dims, expected",
+    [
+        ([[1.0, 0.95], [1.0, 1.05], [1.0, 0.2]], 0.2, 2.0, [3, 3, -1]),
+        ([[1.0, 1.99], [1.0, 0.05], [1.0, 1.95]], 0.2, 2.0, [4, 3, 4]),
+        ([[0.2, 1.99], [0.2, 0.05], [0.2, 1.95]], 0.2, (0.4, 2.0), [4, 3, 4]),
+        ([[0.39, 1.0], [0.02, 1.0], [0.38, 1.0]], 0.2, (0.4, 2.0), [4, 3, 4]),
+    ],
+)
+def test_nearest_neighbour_non_unit_region(
+    x: List[List[float]],
+    i_range: float,
+    dims: Union[float, Tuple[float, float]],
+    expected: List[int],
+):
+    x = jnp.array(x)
+
+    def foo(params, a, b):
+        return params + a + b
+
+    vals = jnp.arange(x.shape[0])
+    results = transforms.nearest_neighbour(
+        foo, default=-1, topology="moore", i_range=i_range, dims=dims
+    )(2, vals, vals, pos=x)
+
+    assert jnp.array_equal(results, jnp.array(expected))
+
+
+def test_nearest_neighbour_w_rng(rng_key: chex.PRNGKey):
+    x = jnp.array([[0.1, 0.1], [0.1, 0.2]])
+
+    def foo(_p, _a, _b, *, key):
+        return jax.random.choice(key, 10_000, ())
+
+    results = transforms.nearest_neighbour(foo, default=-1, i_range=0.3)(
+        None, None, None, key=rng_key, pos=x
+    )
+
+    assert results.shape == (2,)
+    assert results[0] != results[1]

--- a/tests/test_transforms/test_space.py
+++ b/tests/test_transforms/test_space.py
@@ -322,33 +322,6 @@ def test_mixed_type_spatial_interaction(
 
 
 @pytest.mark.parametrize(
-    "expected, topology, i_range",
-    [
-        ([3, 3, -1], "same-cell", 10.0),
-        ([3, 3, 5], "von-neumann", 10.0),
-        ([3, 3, 5], "moore", 10.0),
-        ([-1, -1, -1], "moore", 0.00001),
-    ],
-)
-def test_nearest_neighbour(expected: chex.Array, topology: str, i_range: float):
-    k = jax.random.PRNGKey(101)
-    x = jnp.array([[0.1, 0.1], [0.1, 0.2], [0.1, 0.6]])
-
-    def foo(_, params, a, b):
-        return params + a + b
-
-    vals = jnp.arange(3)
-    results = transforms.nearest_neighbour(
-        foo, n_bins=2, default=-1, topology=topology, i_range=i_range
-    )(k, 2, vals, vals, pos=x)
-
-    assert jnp.array_equal(
-        results,
-        jnp.array(expected),
-    )
-
-
-@pytest.mark.parametrize(
     "n_agents, i_range",
     [
         (2, 0.1),
@@ -556,32 +529,3 @@ def test_parameter_checks():
         match="Dimensions should be a multiple of i_range",
     ):
         transforms._space._process_parameters(0.25, [1.0, 0.8], None)
-
-
-@pytest.mark.parametrize(
-    "x, i_range, dims, expected",
-    [
-        ([[1.0, 0.95], [1.0, 1.05], [1.0, 0.2]], 0.2, 2.0, [3, 3, -1]),
-        ([[1.0, 1.99], [1.0, 0.05], [1.0, 1.95]], 0.2, 2.0, [4, 3, 4]),
-        ([[0.2, 1.99], [0.2, 0.05], [0.2, 1.95]], 0.2, (0.4, 2.0), [4, 3, 4]),
-        ([[0.39, 1.0], [0.02, 1.0], [0.38, 1.0]], 0.2, (0.4, 2.0), [4, 3, 4]),
-    ],
-)
-def test_nearest_neighbour_non_unit_region(
-    x: List[List[float]],
-    i_range: float,
-    dims: Union[float, Tuple[float, float]],
-    expected: List[int],
-):
-    k = jax.random.PRNGKey(101)
-    x = jnp.array(x)
-
-    def foo(_, params, a, b):
-        return params + a + b
-
-    vals = jnp.arange(x.shape[0])
-    results = transforms.nearest_neighbour(
-        foo, default=-1, topology="moore", i_range=i_range, dims=dims
-    )(k, 2, vals, vals, pos=x)
-
-    assert jnp.array_equal(results, jnp.array(expected))


### PR DESCRIPTION
Make passing of random keys to transformed functions optional. Keys can now be provided by including keyword argument in the function signature.